### PR TITLE
Define STRICT_R_HEADERS, change PI to M_PI

### DIFF
--- a/inst/include/gate.hpp
+++ b/inst/include/gate.hpp
@@ -81,22 +81,22 @@ bool trigo_pnt_in_poly (const Rcpp::NumericVector pnt,
     x1 = poly(i, 0); x2 = poly((i + 1), 0); x = pnt[0];
     y1 = poly(i, 1); y2 = poly((i + 1), 1); y = pnt[1];
     //check if point is vertix
-    if (x == x1 && y == y1) { angle = PI + 1; break; }
+    if (x == x1 && y == y1) { angle = M_PI + 1; break; }
     //check if point is on border line between 2 points
-    if (x == x1 && x == x2) { if ((y1 <= y && y <= y2) || (y1 >= y && y >= y2)) { angle = PI + 1; break; } } // check point between two horizontal points
-    if (y == y1 && y == y2) { if ((x1 <= x && x <= x2) || (x1 >= x && x >= x2)) { angle = PI + 1; break; } } // check point between two verticle points
+    if (x == x1 && x == x2) { if ((y1 <= y && y <= y2) || (y1 >= y && y >= y2)) { angle = M_PI + 1; break; } } // check point between two horizontal points
+    if (y == y1 && y == y2) { if ((x1 <= x && x <= x2) || (x1 >= x && x >= x2)) { angle = M_PI + 1; break; } } // check point between two verticle points
     dy = (y1==y2) ? -9999:(y1-y)/(y1-y2); //check if the relative change in x == relative change in y
     dx = (x1==x2) ? -9999:(x1-x)/(x1-x2); //check if the relative change in x == relative change in y
     dd = dy-dx; dd = (dd<0) ? -dd:dd;
-    if (dd < epsilon && dy>0 && dy<1) { angle = PI + 1; break; } // if dx == dy and dy is between 0 & 1 ... point is on the border line
+    if (dd < epsilon && dy>0 && dy<1) { angle = M_PI + 1; break; } // if dx == dy and dy is between 0 & 1 ... point is on the border line
     // && dy > 0 && dy < 1
     //if not a vertex or on border lines... sum the angles
     double dtheta = std::atan2(y2 - y, x2 - x) - std::atan2(y1 - y, x1 - x);
-    while (dtheta > PI) dtheta -= 2 * PI;
-    while (dtheta < -PI) dtheta += 2 * PI;
+    while (dtheta > M_PI) dtheta -= 2 * M_PI;
+    while (dtheta < -M_PI) dtheta += 2 * M_PI;
     angle += dtheta;
   }
-  return (std::fabs(angle) >= PI);
+  return (std::fabs(angle) >= M_PI);
 }
 
 //' @title Point in Ellipse

--- a/src/ifc.cpp
+++ b/src/ifc.cpp
@@ -28,6 +28,7 @@
   along with IFC. If not, see <http://www.gnu.org/licenses/>.                   
 */
 
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include "../inst/include/align.hpp"
 #include "../inst/include/assert.hpp"


### PR DESCRIPTION
Dear Yohann, dear IFC team,

Your CRAN package IFC uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, we prefixed one #include <Rcpp.h> with STRICT_R_HEADERS. The actual change that is needed is the change from PI to M_PI in one file.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.